### PR TITLE
Fix deserialization of empty arrays

### DIFF
--- a/deserializer.js
+++ b/deserializer.js
@@ -36,7 +36,12 @@ function decode(value) {
     return { latitude, longitude };
   }
   if ("arrayValue" in value) {
-    return value.arrayValue.values.map((value) => decode(value));
+    if ("values" in value.arrayValue) {
+      return value.arrayValue.values.map((value) => decode(value));
+    }
+    else {
+      return [];
+    }
   }
   if ("mapValue" in value) {
     return deserialize(value.mapValue.fields);

--- a/deserializer.test.js
+++ b/deserializer.test.js
@@ -63,6 +63,16 @@ describe("deserialize", () => {
     ).toEqual({ field: { latitude: 5, longitude: 3.14 } });
   });
 
+  test("empty arrayValue", () => {
+    expect(
+      deserialize({
+        field: {
+          arrayValue: {},
+        },
+      })
+    ).toEqual({ field: [] });
+  });
+
   test("arrayValue", () => {
     expect(
       deserialize({


### PR DESCRIPTION
When a document has an empty array field, the REST api returns an empty object as the "arrayValue" for that field which causes the following error:

    TypeError: Cannot read property 'map' of undefined

      37 |   }
      38 |   if ("arrayValue" in value) {
    > 39 |     return value.arrayValue.values.map((value) => decode(value));
         |                                    ^
      40 |   }
      41 |   if ("mapValue" in value) {
      42 |     return deserialize(value.mapValue.fields);

      at decode (deserializer.js:39:36)
      at map (deserializer.js:4:20)
          at Array.map (<anonymous>)
      at deserialize (deserializer.js:3:28)
      at Object.<anonymous> (deserializer.test.js:68:7)
